### PR TITLE
Replace ListView by a RecyclerView

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,5 +25,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.android.support:gridlayout-v7:23.0.1'
     compile 'com.android.support:design:23.0.1'
+    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.android.support:support-annotations:23.0.1'
     compile fileTree(include: ['*.jar'], dir: 'libs')
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/CreateNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/CreateNoteActivity.java
@@ -49,10 +49,9 @@ public class CreateNoteActivity extends AppCompatActivity {
                 editTextField.setEnabled(false);
                 String content = editTextField.getText().toString();
                 NoteSQLiteOpenHelper db = new NoteSQLiteOpenHelper(this);
-                db.addNoteAndSync(content);
+                long noteId = db.addNoteAndSync(content);
                 Intent data = new Intent();
-                //FIXME send correct note back to NotesListView
-                data.putExtra(NotesListViewActivity.CREATED_NOTE, new Note(-1, null, "", content));
+                data.putExtra(NotesListViewActivity.CREATED_NOTE, db.getNote(noteId));
                 setResult(RESULT_OK, data);
                 finish();
                 return true;

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -7,30 +7,24 @@ import android.preference.PreferenceManager;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.ActionMode;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.util.Log;
-import android.util.SparseBooleanArray;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.AdapterView;
-import android.widget.AdapterView.OnItemClickListener;
-import android.widget.AdapterView.OnItemLongClickListener;
-import android.widget.ListView;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 
 import it.niedermann.owncloud.notes.R;
-import it.niedermann.owncloud.notes.model.Item;
-import it.niedermann.owncloud.notes.model.ItemAdapter;
 import it.niedermann.owncloud.notes.model.Note;
-import it.niedermann.owncloud.notes.model.SectionItem;
+import it.niedermann.owncloud.notes.model.NoteAdapter;
 import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
 import it.niedermann.owncloud.notes.util.ICallback;
 
-public class NotesListViewActivity extends AppCompatActivity implements
-        OnItemClickListener, View.OnClickListener {
+public class NotesListViewActivity extends AppCompatActivity implements View.OnClickListener, NoteAdapter.NoteClickListener {
 
     public final static String SELECTED_NOTE = "it.niedermann.owncloud.notes.clicked_note";
     public final static String CREATED_NOTE = "it.niedermann.owncloud.notes.created_notes";
@@ -42,8 +36,7 @@ public class NotesListViewActivity extends AppCompatActivity implements
     private final static int server_settings = 2;
     private final static int about = 3;
 
-    private ListView listView = null;
-    private ItemAdapter adapter = null;
+    private NoteAdapter adapter;
     private ActionMode mActionMode;
     private SwipeRefreshLayout swipeRefreshLayout = null;
     private NoteSQLiteOpenHelper db = null;
@@ -60,6 +53,13 @@ public class NotesListViewActivity extends AppCompatActivity implements
         }
 
         setContentView(R.layout.activity_notes_list_view);
+
+        adapter = new NoteAdapter(this, this);
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+        recyclerView.setAdapter(adapter);
+        recyclerView.setItemAnimator(new DefaultItemAnimator());
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
 
         // Display Data
         db = new NoteSQLiteOpenHelper(this);
@@ -105,110 +105,8 @@ public class NotesListViewActivity extends AppCompatActivity implements
      *
      * @param noteList List&lt;Note&gt;
      */
-    @SuppressWarnings("WeakerAccess")
     public void setListView(List<Note> noteList) {
-        List<Item> itemList = new ArrayList<>();
-        // #12 Create Sections depending on Time
-        // TODO Move to ItemAdapter?
-        boolean recentSet, todaySet, yesterdaySet, weekSet, monthSet, earlierSet;
-        recentSet = todaySet = yesterdaySet = weekSet = monthSet = earlierSet = false;
-        Calendar recent = Calendar.getInstance();
-        Calendar today = Calendar.getInstance();
-        today.set(Calendar.HOUR_OF_DAY, 0);
-        today.set(Calendar.MINUTE, 0);
-        today.set(Calendar.SECOND, 0);
-        today.set(Calendar.MILLISECOND, 0);
-        Calendar yesterday = Calendar.getInstance();
-        yesterday.set(Calendar.DAY_OF_YEAR, yesterday.get(Calendar.DAY_OF_YEAR) - 1);
-        yesterday.set(Calendar.HOUR_OF_DAY, 0);
-        yesterday.set(Calendar.MINUTE, 0);
-        yesterday.set(Calendar.SECOND, 0);
-        yesterday.set(Calendar.MILLISECOND, 0);
-        Calendar week = Calendar.getInstance();
-        week.set(Calendar.DAY_OF_WEEK, week.getFirstDayOfWeek());
-        week.set(Calendar.HOUR_OF_DAY, 0);
-        week.set(Calendar.MINUTE, 0);
-        week.set(Calendar.SECOND, 0);
-        week.set(Calendar.MILLISECOND, 0);
-        Calendar month = Calendar.getInstance();
-        month.set(Calendar.DAY_OF_MONTH, 0);
-        month.set(Calendar.HOUR_OF_DAY, 0);
-        month.set(Calendar.MINUTE, 0);
-        month.set(Calendar.SECOND, 0);
-        month.set(Calendar.MILLISECOND, 0);
-        for (int i = 0; i < noteList.size(); i++) {
-            Note currentNote = noteList.get(i);
-            if (!recentSet && recent.getTimeInMillis() - currentNote.getModified().getTimeInMillis() < 600000) {
-                // < 10 minutes
-                itemList.add(new SectionItem(getResources().getString(R.string.listview_updated_recent)));
-                recentSet = true;
-            } else if (!todaySet && recent.getTimeInMillis() - currentNote.getModified().getTimeInMillis() >= 600000 && currentNote.getModified().getTimeInMillis() >= today.getTimeInMillis()) {
-                // < 10 minutes but after 00:00 today
-                itemList.add(new SectionItem(getResources().getString(R.string.listview_updated_today)));
-                todaySet = true;
-            } else if (!yesterdaySet && currentNote.getModified().getTimeInMillis() < today.getTimeInMillis() && currentNote.getModified().getTimeInMillis() >= yesterday.getTimeInMillis()) {
-                // between today 00:00 and yesterday 00:00
-                itemList.add(new SectionItem(getResources().getString(R.string.listview_updated_yesterday)));
-                yesterdaySet = true;
-            } else if (!weekSet && currentNote.getModified().getTimeInMillis() < yesterday.getTimeInMillis() && currentNote.getModified().getTimeInMillis() >= week.getTimeInMillis()) {
-                // between yesterday 00:00 and start of the week 00:00
-                itemList.add(new SectionItem(getResources().getString(R.string.listview_updated_this_week)));
-                weekSet = true;
-            } else if (!monthSet && currentNote.getModified().getTimeInMillis() < week.getTimeInMillis() && currentNote.getModified().getTimeInMillis() >= month.getTimeInMillis()) {
-                // between start of the week 00:00 and start of the month 00:00
-                itemList.add(new SectionItem(getResources().getString(R.string.listview_updated_this_month)));
-                monthSet = true;
-            } else if (!earlierSet && currentNote.getModified().getTimeInMillis() < month.getTimeInMillis()) {
-                // before start of the month 00:00
-                itemList.add(new SectionItem(getResources().getString(R.string.listview_updated_earlier)));
-                earlierSet = true;
-            }
-            itemList.add(currentNote);
-        }
-
-        adapter = new ItemAdapter(getApplicationContext(), itemList);
-        listView = (ListView) findViewById(R.id.list_view);
-        listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
-        listView.setAdapter(adapter);
-        listView.setOnItemClickListener(this);
-        listView.setOnItemLongClickListener(new OnItemLongClickListener() {
-            @Override
-            public boolean onItemLongClick(AdapterView<?> parent, View view,
-                                           int position, long id) {
-                onListItemSelect(position);
-                return true;
-            }
-        });
-    }
-
-    /**
-     * A short click on one list item. Creates a new instance of NoteActivity.
-     */
-    @Override
-    public void onItemClick(AdapterView<?> parentView, View childView,
-                            int position, long id) {
-        Item item = adapter.getItem(position);
-        if (!item.isSection()) {
-            listView.setItemChecked(position, !listView.isItemChecked(position));
-            Log.v("Note", "getCheckedItemCount " + listView.getCheckedItemCount());
-            if (listView.getCheckedItemCount() < 1) {
-                removeSelection();
-                Intent intent = new Intent(getApplicationContext(),
-                        NoteActivity.class);
-                if (!item.isSection()) {
-                    intent.putExtra(SELECTED_NOTE, (Note) item);
-                    intent.putExtra(SELECTED_NOTE_POSITION, position);
-                    Log.v("Note",
-                            "notePosition | NotesListViewActivity wurde abgesendet "
-                                    + position);
-                    startActivityForResult(intent, show_single_note_cmd);
-                }
-            } else { // perform long click if already something is selected
-                onListItemSelect(position);
-            }
-        } else {
-            listView.setItemChecked(position, false);
-        }
+        adapter.replaceNotes(noteList);
     }
 
     /**
@@ -259,71 +157,75 @@ public class NotesListViewActivity extends AppCompatActivity implements
         if (requestCode == create_note_cmd) {
             // Make sure the request was successful
             if (resultCode == RESULT_OK) {
-                Note createdNote = (Note) data.getExtras().getSerializable(
-                        CREATED_NOTE);
-                adapter.add(createdNote);
+                Note createdNote = (Note) data.getExtras().getSerializable(CREATED_NOTE);
+                adapter.addNote(createdNote);
             }
         } else if (requestCode == NoteActivity.EDIT_NOTE_CMD) {
             if (resultCode == RESULT_OK) {
                 Note editedNote = (Note) data.getExtras().getSerializable(
                         NoteActivity.EDIT_NOTE);
-                int notePosition = data.getExtras().getInt(
-                        SELECTED_NOTE_POSITION);
-                adapter.remove(adapter.getItem(notePosition));
-                adapter.add(editedNote);
+                int notePosition = data.getExtras().getInt(SELECTED_NOTE_POSITION);
+                adapter.replaceNote(notePosition, editedNote);
             }
         } else if (requestCode == SettingsActivity.CREDENTIALS_CHANGED) {
             db = new NoteSQLiteOpenHelper(this);
             db.synchronizeWithServer(); // Needed to instanciate new NotesClient with new URL
+            // TODO: should probably wait for a DB event?
+            setListView(db.getNotes());
         }
-        //TODO Maybe only if previous activity == settings activity?
-        setListView(db.getNotes());
+    }
+
+    @Override
+    public void onNoteClicked(int position) {
+        if (mActionMode != null) {
+            toggleSelection(position);
+        } else {
+            Intent intent = new Intent(getApplicationContext(), NoteActivity.class);
+            intent.putExtra(SELECTED_NOTE, adapter.getNote(position));
+            intent.putExtra(SELECTED_NOTE_POSITION, position);
+            Log.v("Note", "notePosition | NotesListViewActivity wurde abgesendet "
+                    + position);
+            startActivityForResult(intent, show_single_note_cmd);
+        }
+    }
+
+    @Override
+    public boolean onNoteLong(int position) {
+        if (mActionMode == null) {
+            // TODO differ if one or more items are selected
+            mActionMode = startSupportActionMode(new MultiSelectedActionModeCallback());
+        }
+
+        toggleSelection(position);
+
+        return true;
     }
 
     /**
-     * Long click on one item in the list view. It starts the Action Mode and allows selecting more
-     * items and execute bulk functions (e. g. delete)
+     * Toggle the selection state of a note.
      *
-     * @param position int - position of the clicked item
+     * If the note was the last one in the selection and is unselected, the selection is stopped.
+     * Note that the selection must already be started (mActionMode must not be null).
+     *
+     * @param position Position of the item to toggle the selection state
      */
-    private void onListItemSelect(int position) {
-        if (!adapter.getItem(position).isSection()) {
-            listView.setItemChecked(position, !listView.isItemChecked(position));
-            int checkedItemCount = listView.getCheckedItemCount();
-            boolean hasCheckedItems = checkedItemCount > 0;
+    private void toggleSelection(int position) {
+        adapter.toggleSelection(position);
+        int count = adapter.getSelectedItemCount();
 
-            if (hasCheckedItems && mActionMode == null) {
-                // TODO differ if one or more items are selected
-                // if (checkedItemCount == 1) {
-                // mActionMode = startActionMode(new
-                // SingleSelectedActionModeCallback());
-                // } else {
-                // there are some selected items, start the actionMode
-                mActionMode = startSupportActionMode(new MultiSelectedActionModeCallback());
-                // }
-            } else if (!hasCheckedItems && mActionMode != null) {
-                // there no selected items, finish the actionMode
-                mActionMode.finish();
-            }
-
-            if (mActionMode != null) {
-                mActionMode.setTitle(String.valueOf(listView.getCheckedItemCount())
-                        + " " + getString(R.string.ab_selected));
-            }
+        if (count == 0) {
+            mActionMode.finish();
         } else {
-            listView.setItemChecked(position, false);
+            mActionMode.setTitle(String.valueOf(adapter.getSelectedItemCount()) + " " + getString(R.string.ab_selected));
         }
     }
+
 
     /**
      * Removes all selections.
      */
     private void removeSelection() {
-        SparseBooleanArray checkedItemPositions = listView
-                .getCheckedItemPositions();
-        for (int i = 0; i < checkedItemPositions.size(); i++) {
-            listView.setItemChecked(i, false);
-        }
+        adapter.clearSelection();
     }
 
     /**
@@ -354,15 +256,15 @@ public class NotesListViewActivity extends AppCompatActivity implements
         public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
             switch (item.getItemId()) {
                 case R.id.menu_delete:
-                    SparseBooleanArray checkedItemPositions = listView
-                            .getCheckedItemPositions();
-                    for (int i = (checkedItemPositions.size() - 1); i >= 0; i--) {
-                        if (checkedItemPositions.valueAt(i)) {
-                            Note note = (Note) adapter.getItem(checkedItemPositions
-                                    .keyAt(i));
-                            db.deleteNoteAndSync(note.getId());
-                            adapter.remove(note);
-                        }
+                    List<Integer> checkedItemPositions = adapter.getSelectedItems();
+                    List<Note> notesToRemove = new ArrayList<>();
+                    for (Integer position : checkedItemPositions) {
+                        notesToRemove.add(adapter.getNote(position));
+                    }
+                    adapter.removeNotes(notesToRemove);
+                    // TODO: sync only once?
+                    for (Note note : notesToRemove) {
+                        db.deleteNoteAndSync(note.getId());
                     }
                     mode.finish(); // Action picked, so close the CAB
                     return true;

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SelectSingleNoteActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SelectSingleNoteActivity.java
@@ -23,6 +23,7 @@ import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
 /**
  * Configuration Activity to select a single note which should be displayed in the SingleNoteWidget
  * Created by stefan on 08.10.15.
+ * TODO: use a RecyclerView and NoteAdapter instead of ListView/ItemAdapter
  */
 public class SelectSingleNoteActivity extends AppCompatActivity implements AdapterView.OnItemClickListener {
 

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/Item.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/Item.java
@@ -1,8 +1,11 @@
 package it.niedermann.owncloud.notes.model;
 
+import java.util.Calendar;
+
 /**
  * Created by stefan on 23.10.15.
  */
 public interface Item {
     boolean isSection();
+    Calendar getDate();
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/Note.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/Note.java
@@ -82,4 +82,9 @@ public class Note implements Item, Serializable {
     public boolean isSection() {
         return false;
     }
+
+    @Override
+    public Calendar getDate() {
+        return getModified();
+    }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/NoteAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/NoteAdapter.java
@@ -1,0 +1,290 @@
+package it.niedermann.owncloud.notes.model;
+
+import android.content.Context;
+import android.support.annotation.IntDef;
+import android.support.v7.util.SortedList;
+import android.support.v7.widget.RecyclerView;
+import android.text.format.DateUtils;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Calendar;
+import java.util.Collection;
+
+import it.niedermann.owncloud.notes.R;
+
+public class NoteAdapter extends SelectableAdapter<RecyclerView.ViewHolder> {
+    @SuppressWarnings("unused")
+    private static final String TAG = NoteAdapter.class.getSimpleName();
+
+    private SortedList<Note> notes;
+    private Context context;
+    private NoteClickListener listener;
+
+    @IntDef({
+            RECENTLY,
+            TODAY,
+            YESTERDAY,
+            THIS_WEEK,
+            THIS_MONTH,
+            EARLIER,
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Timeframe {}
+    public static final int RECENTLY = 0;
+    public static final int TODAY = 1;
+    public static final int YESTERDAY = 2;
+    public static final int THIS_WEEK = 3;
+    public static final int THIS_MONTH = 4;
+    public static final int EARLIER = 5;
+
+    @IntDef({
+            TYPE_NOTE,
+            TYPE_SECTION,
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ItemType {}
+    public static final int TYPE_NOTE = 0;
+    public static final int TYPE_SECTION = 1;
+
+    public NoteAdapter(Context context, NoteClickListener listener) {
+        notes = new SortedList<>(Note.class, new SortedList.Callback<Note>() {
+            @Override
+            public int compare(Note o1, Note o2) {
+                // Reverse Calendar.compareTo result to sort most recent first
+                return -o1.getModified().compareTo(o2.getModified());
+            }
+
+            @Override
+            public void onInserted(int position, int count) {
+                notifyItemRangeInserted(position, count);
+            }
+
+            @Override
+            public void onRemoved(int position, int count) {
+                notifyItemRangeRemoved(position, count);
+            }
+
+            @Override
+            public void onMoved(int fromPosition, int toPosition) {
+                notifyItemMoved(fromPosition, toPosition);
+            }
+
+            @Override
+            public void onChanged(int position, int count) {
+                notifyItemRangeChanged(position, count);
+            }
+
+            @Override
+            public boolean areContentsTheSame(Note oldItem, Note newItem) {
+                return oldItem.getModified().equals(newItem.getModified()) &&
+                        oldItem.getTitle().equals(newItem.getTitle()) &&
+                        oldItem.getContent().equals(newItem.getContent());
+            }
+
+            @Override
+            public boolean areItemsTheSame(Note item1, Note item2) {
+                return item1.equals(item2);
+            }
+        });
+        this.context = context;
+        this.listener = listener;
+    }
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, @ItemType int viewType) {
+        switch (viewType) {
+            case TYPE_NOTE:
+                return new NoteHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.fragment_notes_list_note_item, parent, false), listener);
+
+            case TYPE_SECTION:
+                return new SectionHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.fragment_notes_list_section_item, parent, false));
+
+            default:
+                // Unreachable
+                return null;
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+        if (holder instanceof NoteHolder) {
+            ((NoteHolder) holder).bind(notes.get(position), position);
+        } else if (holder instanceof SectionHolder) {
+            // TODO: bind holder
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return notes.size();
+    }
+
+    @Override
+    public @ItemType int getItemViewType(int position) {
+        // TODO: handle sections
+        return TYPE_NOTE;
+    }
+
+    public void addNote(Note note) {
+        notes.add(note);
+    }
+
+    public void replaceNote(int position, Note note) {
+        notes.updateItemAt(position, note);
+    }
+
+    public void replaceNotes(Collection<Note> notes) {
+        this.notes.beginBatchedUpdates();
+        this.notes.clear();
+        this.notes.addAll(notes);
+        this.notes.endBatchedUpdates();
+    }
+
+    public void removeNotes(Collection<Note> notes) {
+        this.notes.beginBatchedUpdates();
+        for (Note note : notes) {
+            this.notes.remove(note);
+        }
+        this.notes.endBatchedUpdates();
+    }
+
+    public Note getNote(int position) {
+        return notes.get(position);
+    }
+
+    private static @Timeframe int getNoteTimeframe(Note note) {
+        Calendar recent = Calendar.getInstance();
+        Calendar today = Calendar.getInstance();
+        today.set(Calendar.HOUR_OF_DAY, 0);
+        today.set(Calendar.MINUTE, 0);
+        today.set(Calendar.SECOND, 0);
+        today.set(Calendar.MILLISECOND, 0);
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.set(Calendar.DAY_OF_YEAR, yesterday.get(Calendar.DAY_OF_YEAR) - 1);
+        yesterday.set(Calendar.HOUR_OF_DAY, 0);
+        yesterday.set(Calendar.MINUTE, 0);
+        yesterday.set(Calendar.SECOND, 0);
+        yesterday.set(Calendar.MILLISECOND, 0);
+        Calendar week = Calendar.getInstance();
+        week.set(Calendar.DAY_OF_WEEK, week.getFirstDayOfWeek());
+        week.set(Calendar.HOUR_OF_DAY, 0);
+        week.set(Calendar.MINUTE, 0);
+        week.set(Calendar.SECOND, 0);
+        week.set(Calendar.MILLISECOND, 0);
+        Calendar month = Calendar.getInstance();
+        month.set(Calendar.DAY_OF_MONTH, 0);
+        month.set(Calendar.HOUR_OF_DAY, 0);
+        month.set(Calendar.MINUTE, 0);
+        month.set(Calendar.SECOND, 0);
+        month.set(Calendar.MILLISECOND, 0);
+
+        long noteModified = note.getModified().getTimeInMillis();
+
+        if (recent.getTimeInMillis() - noteModified < 600000) {
+            return RECENTLY;
+        } else if (recent.getTimeInMillis() - noteModified >= 600000 && noteModified >= today.getTimeInMillis()) {
+            return TODAY;
+        } else if (noteModified < today.getTimeInMillis() && noteModified >= yesterday.getTimeInMillis()) {
+            return YESTERDAY;
+        } else if (noteModified < yesterday.getTimeInMillis() && noteModified >= week.getTimeInMillis()) {
+            return THIS_WEEK;
+        } else if (noteModified < week.getTimeInMillis() && noteModified >= month.getTimeInMillis()) {
+            return THIS_MONTH;
+        } else {
+            return EARLIER;
+        }
+    }
+
+    public interface NoteClickListener {
+        void onNoteClicked(int position);
+        boolean onNoteLong(int position);
+    }
+
+    private final class NoteHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
+        private View root;
+        private TextView title;
+        private TextView excerpt;
+        private TextView modified;
+        private NoteClickListener listener;
+
+        public NoteHolder(View itemView, NoteClickListener listener) {
+            super(itemView);
+
+            this.listener = listener;
+            root = itemView;
+            title = (TextView) itemView.findViewById(R.id.noteTitle);
+            excerpt = (TextView) itemView.findViewById(R.id.noteExcerpt);
+            modified = (TextView) itemView.findViewById(R.id.noteModified);
+
+            itemView.setOnClickListener(this);
+            itemView.setOnLongClickListener(this);
+        }
+
+        @Override
+        public void onClick(View v) {
+            if (listener != null) {
+                listener.onNoteClicked(getAdapterPosition());
+            }
+        }
+
+        @Override
+        public boolean onLongClick(View v) {
+            return listener != null && listener.onNoteLong(getAdapterPosition());
+
+        }
+
+        protected void bind(Note note, int position) {
+            root.setSelected(isSelected(position));
+            title.setText(note.getTitle());
+            excerpt.setText(note.getExcerpt());
+            modified.setText(DateUtils.getRelativeDateTimeString(context, note.getModified().getTimeInMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.WEEK_IN_MILLIS, 0));
+        }
+    }
+
+    private final class SectionHolder extends RecyclerView.ViewHolder {
+        private TextView title;
+
+        public SectionHolder(View itemView) {
+            super(itemView);
+
+            title = (TextView) itemView.findViewById(R.id.sectionTitle);
+        }
+
+        protected void bind(@Timeframe int timeframe) {
+            int strId;
+            switch (timeframe) {
+                case RECENTLY:
+                    strId = R.string.listview_updated_recent;
+                    break;
+
+                case TODAY:
+                    strId = R.string.listview_updated_today;
+                    break;
+
+                case YESTERDAY:
+                    strId = R.string.listview_updated_yesterday;
+                    break;
+
+                case THIS_WEEK:
+                    strId = R.string.listview_updated_this_week;
+                    break;
+
+                case THIS_MONTH:
+                    strId = R.string.listview_updated_this_month;
+                    break;
+
+                default:
+                case EARLIER:
+                    strId = R.string.listview_updated_earlier;
+                    break;
+            }
+            title.setText(context.getString(strId));
+        }
+    }
+}

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/SectionItem.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/SectionItem.java
@@ -1,11 +1,15 @@
 package it.niedermann.owncloud.notes.model;
 
+import java.util.Calendar;
+
 /**
  * Created by stefan on 23.10.15.
  */
 public class SectionItem implements Item {
-    String title = "";
+    private String title = "";
+    private Calendar date;
 
+    // TODO: generate the title, only store the date
     public SectionItem(String title) {
         this.title = title;
     }
@@ -21,5 +25,15 @@ public class SectionItem implements Item {
     @Override
     public boolean isSection() {
         return true;
+    }
+
+    @Override
+    public Calendar getDate() {
+        return date;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o != null && (o == this || o instanceof SectionItem && ((SectionItem) o).getDate().equals(getDate()));
     }
 }

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/SelectableAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/SelectableAdapter.java
@@ -1,0 +1,72 @@
+package it.niedermann.owncloud.notes.model;
+
+import android.support.v7.widget.RecyclerView;
+import android.util.SparseBooleanArray;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class SelectableAdapter<VH extends RecyclerView.ViewHolder> extends RecyclerView.Adapter<VH> {
+    @SuppressWarnings("unused")
+    private static final String TAG = SelectableAdapter.class.getSimpleName();
+
+    private SparseBooleanArray selectedItems;
+
+    public SelectableAdapter() {
+        selectedItems = new SparseBooleanArray();
+    }
+
+    /**
+     * Indicates if the item at position position is selected
+     * @param position Position of the item to check
+     * @return true if the item is selected, false otherwise
+     */
+    public boolean isSelected(int position) {
+        return getSelectedItems().contains(position);
+    }
+
+    /**
+     * Toggle the selection status of the item at a given position
+     * @param position Position of the item to toggle the selection status for
+     */
+    public void toggleSelection(int position) {
+        if (selectedItems.get(position, false)) {
+            selectedItems.delete(position);
+        } else {
+            selectedItems.put(position, true);
+        }
+        notifyItemChanged(position);
+    }
+
+    /**
+     * Clear the selection status for all items
+     */
+    public void clearSelection() {
+        List<Integer> selection = getSelectedItems();
+        selectedItems.clear();
+        for (Integer i : selection) {
+            notifyItemChanged(i);
+        }
+    }
+
+    /**
+     * Count the selected items
+     * @return Selected items count
+     */
+    public int getSelectedItemCount() {
+        return selectedItems.size();
+    }
+
+    /**
+     * Indicates the list of selected items
+     * @return List of selected items ids
+     */
+    public List<Integer> getSelectedItems() {
+        List<Integer> items = new ArrayList<>(selectedItems.size());
+        for (int i = 0; i < selectedItems.size(); ++i) {
+            items.add(selectedItems.keyAt(i));
+        }
+        return items;
+    }
+}
+

--- a/app/src/main/res/drawable/list_item_background_selector.xml
+++ b/app/src/main/res/drawable/list_item_background_selector.xml
@@ -2,6 +2,7 @@
 <!-- Selector is used for Background Colors in List Items -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- :selected -->
+    <item android:drawable="@color/bg_highlighted" android:state_selected="true"/>
     <item android:drawable="@color/bg_highlighted" android:state_activated="true"/>
     <item android:drawable="@color/bg_normal"/>
 </selector>

--- a/app/src/main/res/layout/activity_notes_list_view.xml
+++ b/app/src/main/res/layout/activity_notes_list_view.xml
@@ -13,11 +13,11 @@
         tools:context="it.niedermann.owncloud.notes.android.activity.NotesListViewActivity"
         tools:ignore="MergeRootFrame">
 
-        <ListView
-            android:id="@+id/list_view"
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-        </ListView>
+        </android.support.v7.widget.RecyclerView>
     </android.support.v4.widget.SwipeRefreshLayout>
 
     <android.support.design.widget.FloatingActionButton

--- a/app/src/main/res/layout/fragment_notes_list_note_item.xml
+++ b/app/src/main/res/layout/fragment_notes_list_note_item.xml
@@ -5,7 +5,10 @@
     android:layout_width="fill_parent"
     android:layout_height="?android:attr/listPreferredItemHeight"
     android:background="@drawable/list_item_background_selector"
-    android:padding="16dp">
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
 
     <TextView
         android:id="@+id/noteTitle"


### PR DESCRIPTION
(Dot **not** merge yet, it's still WIP)

This PR will fix #30 and migrate from `ListView`s to `RecyclerView`s, allowing more flexibility. For now, I simply replaced the `ListView` in one activity (`NotesListViewActivity`). To do:
- [x] Fix note creation callback
- [x] Replace `ListView` by `RecyclerView` in `NotesListViewActivity`
- [ ] Replace `ListView` by `RecyclerView` in `SelectSingleNoteActivity`
- [ ] Implement back the sections pattern in the new `NoteAdapter` (replacing the `ItemAdapter`)
- [ ] Add some separators between items (handled automatically by `ListView`, to do manually with a `RecyclerView`)

The `NoteAdapter` uses a `SortedList` to store `Notes`, and is always sorted (here's the fix to #30, mainly a side-effect of switching to `RecyclerView` ;-))