### PR TITLE
Quick fix for #91: Use another string to indicate invalid login

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
@@ -239,7 +239,7 @@ public class SettingsActivity extends AppCompatActivity {
                 Log.e("Note", "invalid login");
                 btn_submit.setText(R.string.settings_submit);
                 setInputsEnabled(true);
-                Toast.makeText(getApplicationContext(), getString(R.string.error_username_password_invalid), Toast.LENGTH_LONG).show();
+                Toast.makeText(getApplicationContext(), getString(R.string.invalid_login), Toast.LENGTH_LONG).show();
             }
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,9 +29,8 @@
     <string name="listview_updated_earlier">Früher</string>
 
     <!-- Settings -->
-
     <string name="settings_server">Server</string>
-    <string name="settings_url">Server Adresse</string>
+    <string name="settings_url">Server-Adresse</string>
     <string name="settings_url_check_description">Zeigt an, ob die angegebene URL erreichbar ist.</string>
     <string name="settings_url_warn_http">WARNUNG: "http" ist unsicher. Bitte benutzen Sie "https".</string>
     <string name="settings_username">Benutzername</string>
@@ -41,23 +40,21 @@
     <string name="settings_submitting">Verbindet&#8230;</string>
 
     <!-- Network -->
-
     <string name="network_connecting">Verbindung wird hergestellt</string>
     <string name="network_connected">Verbunden</string>
     <string name="network_disconnected">Kein Netzwerk verfügbar</string>
 
     <!-- Error -->
-
+    <string name="error_json">JSON-Fehler</string>
+    <string name="error_io">IO-Fehler</string>
+    <string name="error_invalid login">Login fehlgeschlagen</string>
     <string name="error_url_malformed">URL nicht korrekt</string>
-    <string name="error_json">JSON Fehler</string>
-    <string name="error_io">IO Fehler</string>
     <string name="error_username_password_invalid">Benutzername / Passwort nicht korrekt</string>
 
     <!-- Snackbar Actions -->
     <string name="snackbar_settings">Einstellungen</string>
 
     <!-- About -->
-
     <string name="about_version_title">Version</string>
     <string name="about_version">Sie benutzen aktuell <strong>v0.7.0</strong></string>
     <string name="about_maintainer_title">Maintainer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,6 @@
     <string name="listview_updated_earlier">Earlier</string>
 
     <!-- Settings -->
-
     <string name="settings_server">Server</string>
     <string name="settings_url">Server address</string>
     <string name="settings_url_check_description">Shows if the address can be pinged.</string>
@@ -41,16 +40,15 @@
     <string name="settings_submitting">Connecting &#8230;</string>
 
     <!-- Network -->
-
     <string name="network_connecting">Connecting</string>
     <string name="network_connected">Connected</string>
     <string name="network_disconnected">No network available</string>
 
     <!-- Error -->
-
-    <string name="error_url_malformed">Wrong server address</string>
     <string name="error_json">JSON error</string>
     <string name="error_io">IO error</string>
+    <string name="error_invalid_login">Invalid login</string>
+    <string name="error_url_malformed">Wrong server address</string>
     <string name="error_username_password_invalid">Wrong username or password</string>
 
     <!-- Snackbar Actions -->
@@ -58,7 +56,6 @@
 
 
     <!-- About -->
-
     <string name="about_version_title">Version</string>
     <string name="about_version">You are currently using <strong>v0.7.0</strong></string>
     <string name="about_maintainer_title">Maintainer</string>


### PR DESCRIPTION
A more detailed info would be desirable, but this also works and doesn't tell the user wrong information.