### PR TITLE
Fix error message for synchronization on first/unconfigured run

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -30,6 +30,7 @@ import it.niedermann.owncloud.notes.model.Item;
 import it.niedermann.owncloud.notes.model.ItemAdapter;
 import it.niedermann.owncloud.notes.model.SectionItem;
 import it.niedermann.owncloud.notes.persistence.NoteSQLiteOpenHelper;
+import it.niedermann.owncloud.notes.persistence.NoteServerSyncHelper;
 import it.niedermann.owncloud.notes.util.ICallback;
 import it.niedermann.owncloud.notes.util.NotesClientUtil;
 
@@ -72,7 +73,7 @@ public class NotesListViewActivity extends AppCompatActivity implements
         // First Run Wizard
         SharedPreferences preferences = PreferenceManager
                 .getDefaultSharedPreferences(getApplicationContext());
-        if (preferences.getBoolean(SettingsActivity.SETTINGS_FIRST_RUN, true)) {
+        if (!NoteServerSyncHelper.isConfigured(this)) {
             Intent settingsIntent = new Intent(this, SettingsActivity.class);
             startActivityForResult(settingsIntent, server_settings);
         }
@@ -107,7 +108,7 @@ public class NotesListViewActivity extends AppCompatActivity implements
      */
     @Override
     protected void onResume() {
-        if (db.getNoteServerSyncHelper().isSyncPossible() && !PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean(SettingsActivity.SETTINGS_FIRST_RUN, true)) {
+        if (db.getNoteServerSyncHelper().isSyncPossible()) {
             synchronize();
         }
         super.onResume();

--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/SettingsActivity.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import it.niedermann.owncloud.notes.R;
+import it.niedermann.owncloud.notes.persistence.NoteServerSyncHelper;
 import it.niedermann.owncloud.notes.util.NotesClientUtil;
 import it.niedermann.owncloud.notes.util.NotesClientUtil.LoginStatus;
 
@@ -28,7 +29,6 @@ import it.niedermann.owncloud.notes.util.NotesClientUtil.LoginStatus;
  */
 public class SettingsActivity extends AppCompatActivity {
 
-    public static final String SETTINGS_FIRST_RUN = "firstRun";
     public static final String SETTINGS_URL = "settingsUrl";
     public static final String SETTINGS_USERNAME = "settingsUsername";
     public static final String SETTINGS_PASSWORD = "settingsPassword";
@@ -50,7 +50,7 @@ public class SettingsActivity extends AppCompatActivity {
         preferences = PreferenceManager
                 .getDefaultSharedPreferences(getApplicationContext());
 
-        if (preferences.getBoolean(SettingsActivity.SETTINGS_FIRST_RUN, true)) {
+        if (!NoteServerSyncHelper.isConfigured(this)) {
             first_run = true;
             getSupportActionBar().setDisplayHomeAsUpEnabled(false);
         }
@@ -223,8 +223,6 @@ public class SettingsActivity extends AppCompatActivity {
                 editor.putString(SETTINGS_URL, url);
                 editor.putString(SETTINGS_USERNAME, username);
                 editor.putString(SETTINGS_PASSWORD, password);
-                // Now it is no more First Run
-                editor.putBoolean(SETTINGS_FIRST_RUN, false);
                 editor.apply();
 
                 //NoteSQLiteOpenHelper db = new NoteSQLiteOpenHelper(getApplicationContext());

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
@@ -100,6 +100,9 @@ public class NoteServerSyncHelper {
         super.finalize();
     }
 
+    public static boolean isConfigured(Context context) {
+        return !PreferenceManager.getDefaultSharedPreferences(context).getString(SettingsActivity.SETTINGS_URL, SettingsActivity.DEFAULT_SETTINGS).isEmpty();
+    }
 
     /**
      * Synchronization is only possible, if there is an active network connection.
@@ -108,7 +111,7 @@ public class NoteServerSyncHelper {
      * @return true if sync is possible, otherwise false.
      */
     public boolean isSyncPossible() {
-        return networkConnected;
+        return networkConnected && isConfigured(appContext);
     }
 
 


### PR DESCRIPTION
See #123 and #130.

I've removed `SettingsActivity.SETTINGS_FIRST_RUN` and introduced `NoteServerSyncHelper.isConfigured()` which checks if `SettingsActivity.SETTINGS_URL` is not empty.