### PR TITLE
More precise error message and logging if `!isSyncPossible()`

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -93,7 +93,8 @@ public class NotesListViewActivity extends AppCompatActivity implements
                     synchronize();
                 } else {
                     swipeRefreshLayout.setRefreshing(false);
-                    Toast.makeText(getApplicationContext(), getString(R.string.error_sync, getString(NotesClientUtil.LoginStatus.NO_NETWORK.str)), Toast.LENGTH_LONG).show();
+                    Log.d("Sync not possible", "NotesListViewActivity/SwipeRefreshLayout.OnRefreshListener (isConfigured="+db.getNoteServerSyncHelper().isConfigured(getApplicationContext())+")");
+                    Toast.makeText(getApplicationContext(), R.string.error_sync_not_possible, Toast.LENGTH_LONG).show();
                 }
             }
         });
@@ -353,7 +354,8 @@ public class NotesListViewActivity extends AppCompatActivity implements
                 swipeRefreshLayout.setRefreshing(true);
                 synchronize();
             } else {
-                Toast.makeText(getApplicationContext(), getString(R.string.error_sync, getString(NotesClientUtil.LoginStatus.NO_NETWORK.str)), Toast.LENGTH_LONG).show();
+                Log.d("Sync not possible", "NotesListViewActivity#onActivityResult/server settings (isConfigured="+db.getNoteServerSyncHelper().isConfigured(getApplicationContext())+")");
+                Toast.makeText(getApplicationContext(), R.string.error_sync_not_possible, Toast.LENGTH_LONG).show();
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -44,6 +44,7 @@
     <string name="network_disconnected">Kein Netzwerk verfügbar</string>
 
     <!-- Error -->
+    <string name="error_sync_not_possible">Bitte Netzwerk verbinden und Account einstellen</string>
     <string name="error_sync">Synchronisation fehlgeschlagen: %1$s</string>
     <string name="error_invalid_login">Login fehlgeschlagen: %1$s</string>
     <string name="error_json">ist die Server-App ownCloud Notes aktiviert?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="network_disconnected">No network available</string>
 
     <!-- Error -->
+    <string name="error_sync_not_possible">Please connect to the network and setup your account</string>
     <string name="error_sync">Synchronization failed: %1$s</string>
     <string name="error_invalid_login">Invalid login: %1$s</string>
     <string name="error_json">is the owncloud Notes app activated on the server?</string>


### PR DESCRIPTION
More logging and a better error message in order to debug #130.

Please test this, @stefan-niedermann, and tell me which log message (tag `Sync not possible` or message `STARTING SYNCHRONIZATION`) you get when the Toast message appears. You do not have to merge this immediately, just checkout for testing.