### PR TITLE
Extend "excerpt" with text from the following lines

### DIFF
--- a/app/src/androidTest/java/it/niedermann/owncloud/notes/util/NoteUtilTest.java
+++ b/app/src/androidTest/java/it/niedermann/owncloud/notes/util/NoteUtilTest.java
@@ -39,7 +39,7 @@ public class NoteUtilTest extends TestCase {
     public void testGenerateNoteExcerpt() {
         assertEquals("Test", NoteUtil.generateNoteExcerpt("Test"));
         assertEquals("Foo", NoteUtil.generateNoteExcerpt("Test\nFoo"));
-        assertEquals("Foo", NoteUtil.generateNoteExcerpt("Test\nFoo\nBar"));
+        assertEquals("Foo   Bar", NoteUtil.generateNoteExcerpt("Test\nFoo\nBar"));
         assertEquals("", NoteUtil.generateNoteExcerpt(""));
     }
 }

--- a/app/src/androidTest/java/it/niedermann/owncloud/notes/util/NoteUtilTest.java
+++ b/app/src/androidTest/java/it/niedermann/owncloud/notes/util/NoteUtilTest.java
@@ -37,7 +37,7 @@ public class NoteUtilTest extends TestCase {
     }
 
     public void testGenerateNoteExcerpt() {
-        assertEquals("Test", NoteUtil.generateNoteExcerpt("Test"));
+        assertEquals("", NoteUtil.generateNoteExcerpt("Test"));
         assertEquals("Foo", NoteUtil.generateNoteExcerpt("Test\nFoo"));
         assertEquals("Foo   Bar", NoteUtil.generateNoteExcerpt("Test\nFoo\nBar"));
         assertEquals("", NoteUtil.generateNoteExcerpt(""));

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/NoteUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/NoteUtil.java
@@ -79,7 +79,10 @@ public class NoteUtil {
      * @return excerpt String
      */
     public static String generateNoteExcerpt(String content) {
-        return truncateString(removeMarkDown(content.replaceAll("^.*\n", "")).trim(), 200).replace("\n", "   ");
+        if (content.contains("\n"))
+            return truncateString(removeMarkDown(content.replaceFirst("^.*\n", "")), 200).replace("\n", "   ");
+        else
+            return "";
     }
 
     /**

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/NoteUtil.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/NoteUtil.java
@@ -62,13 +62,24 @@ public class NoteUtil {
     }
 
     /**
+     * Truncates a string to a desired maximum length.
+     * Like String.substring(int,int), but throw no exception if desired length is longer than the string.
+     * @param str String to truncate
+     * @param len Maximum length of the resulting string
+     * @return truncated string
+     */
+    public static String truncateString(String str, int len) {
+        return str.substring(0, Math.min(len, str.length()));
+    }
+
+    /**
      * Generates an excerpt of a content String (reads second line which is not empty)
      *
      * @param content String
      * @return excerpt String
      */
     public static String generateNoteExcerpt(String content) {
-        return getLineWithoutMarkDown(content, 1);
+        return truncateString(removeMarkDown(content.replaceAll("^.*\n", "")).trim(), 200).replace("\n", "   ");
     }
 
     /**


### PR DESCRIPTION
Currently, only the second line is shown as `excerpt` in the list of notes. However, often the second line is not that interesting. So I propose to show more text from the note.