### PR TITLE
New feature: Cancel edit (restores old state)

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteSQLiteOpenHelper.java
@@ -243,13 +243,18 @@ public class NoteSQLiteOpenHelper extends SQLiteOpenHelper {
      * The title is derived from the new content automatically, and modified date as well as DBStatus are updated, too -- if the content differs to the state in the database.
      *
      * @param oldNote Note to be changed
-     * @param newContent New content
+     * @param newContent New content. If this is <code>null</code>, then <code>oldNote</code> is saved again (useful for undoing changes).
      * @param callback When the synchronization is finished, this callback will be invoked (optional).
      * @return changed note if differs from database, otherwise the old note.
      */
     public DBNote updateNoteAndSync(DBNote oldNote, String newContent, ICallback callback) {
         debugPrintFullDB();
-        DBNote newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), Calendar.getInstance(), NoteUtil.generateNoteTitle(newContent), newContent, DBStatus.LOCAL_EDITED);
+        DBNote newNote;
+        if(newContent==null) {
+            newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), oldNote.getModified(), oldNote.getTitle(), oldNote.getContent(), DBStatus.LOCAL_EDITED);
+        } else {
+            newNote = new DBNote(oldNote.getId(), oldNote.getRemoteId(), Calendar.getInstance(), NoteUtil.generateNoteTitle(newContent), newContent, DBStatus.LOCAL_EDITED);
+        }
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues values = new ContentValues();
         values.put(key_status, newNote.getStatus().getTitle());

--- a/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/persistence/NoteServerSyncHelper.java
@@ -222,13 +222,13 @@ public class NoteServerSyncHelper {
                             // if note is not new, try to edit it.
                             if (note.getRemoteId()>0) {
                                 Log.d(getClass().getSimpleName(), "   ...try to edit");
-                                remoteNote = client.editNote(note.getRemoteId(), note.getContent());
+                                remoteNote = client.editNote(note);
                             }
                             // However, the note may be deleted on the server meanwhile; or was never synchronized -> (re)create
                             // Please note, thas dbHelper.updateNote() realizes an optimistic conflict resolution, which is required for parallel changes of this Note from the UI.
                             if (remoteNote == null) {
                                 Log.d(getClass().getSimpleName(), "   ...Note does not exist on server -> (re)create");
-                                remoteNote = client.createNote(note.getContent());
+                                remoteNote = client.createNote(note);
                                 dbHelper.updateNote(note.getId(), remoteNote, note);
                             } else {
                                 dbHelper.updateNote(note.getId(), remoteNote, note);

--- a/app/src/main/res/menu/menu_note_list_view.xml
+++ b/app/src/main/res/menu/menu_note_list_view.xml
@@ -21,6 +21,12 @@
         app:showAsAction="never"
         android:title="@string/menu_copy"/-->
     <item
+        android:id="@+id/menu_cancel"
+        android:icon="@drawable/ic_action_cancel"
+        android:orderInCategory="110"
+        android:title="@string/menu_cancel"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/menu_delete"
         android:icon="@drawable/ic_action_delete"
         android:orderInCategory="120"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,6 +16,7 @@
     <string name="menu_delete">Löschen</string>
     <string name="menu_copy">Kopieren</string>
     <string name="menu_edit">Bearbeiten</string>
+    <string name="menu_cancel">Abbrechen</string>
     <string name="menu_preview">Vorschau</string>
     <string name="menu_share">Teilen</string>
     <string name="menu_about">Über</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="menu_delete">Delete</string>
     <string name="menu_copy">Copy</string>
     <string name="menu_edit">Edit</string>
+    <string name="menu_cancel">Cancel</string>
     <string name="menu_preview">Preview</string>
     <string name="menu_share">Share</string>
     <string name="menu_about">About</string>


### PR DESCRIPTION
In the discussion of #104, a useful feature was mentioned: cancel the edit of a note. This is interesting, because the auto-save feature directly sends all changes to the server. Therefore, the old state has to be stored in memory, and saved again if desired. This action can be triggered using the menu. It is not shown directly in the action bar, because I think it is not often needed. But we can change this very easy.

If the old state is restored, the server would nevertheless increase the `modified` time of the note by default. Therefore, I'm working on a patch for the server (see nextcloud/notes#4), which allows to set the `modified` time by the client. Although, this patch is not yet merged (and of course not in a release version), this pull request for the client can be merged already: The changes are fully backward compatible (except for the fact, that restoring an old state will increase the `modified` time on old servers, but I think we can deal with it)!

### Tasks done
- [x] EditNote: New menu item `cancel`: restores old state of note
- [x] Refactoring of `NotesClient`: remove recurrent code
- [x] send local modified time to server