### PR TITLE
Fix order after edit without changes

### DIFF
--- a/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/android/activity/NotesListViewActivity.java
@@ -371,10 +371,18 @@ public class NotesListViewActivity extends AppCompatActivity implements
         } else if (requestCode == show_single_note_cmd) {
             if (resultCode == RESULT_OK || resultCode == RESULT_FIRST_USER) {
                 int notePosition = data.getExtras().getInt(EditNoteActivity.PARAM_NOTE_POSITION);
-                adapter.remove(adapter.getItem(notePosition));
+                Item oldItem = adapter.getItem(notePosition);
+                if(resultCode == RESULT_FIRST_USER) {
+                    adapter.remove(oldItem);
+                }
                 if (resultCode == RESULT_OK) {
                     DBNote editedNote = (DBNote) data.getExtras().getSerializable(EditNoteActivity.PARAM_NOTE);
-                    adapter.add(editedNote);
+                    if(oldItem instanceof DBNote && !editedNote.getModified().after(((DBNote)oldItem).getModified())) {
+                        adapter.replace(editedNote, notePosition);
+                    } else {
+                        adapter.remove(oldItem);
+                        adapter.add(editedNote);
+                    }
                 }
             }
         } else if (requestCode == server_settings) {

--- a/app/src/main/java/it/niedermann/owncloud/notes/model/ItemAdapter.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/model/ItemAdapter.java
@@ -45,6 +45,16 @@ public class ItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     }
 
     /**
+     * Replaces a note with an updated version
+     * @param note Note with the changes.
+     * @param position position in the list of the node
+     */
+    public void replace(DBNote note, int position) {
+        itemList.set(position, note);
+        notifyItemChanged(position);
+    }
+
+    /**
      * Removes all items from the adapter.
      */
     public void removeAll() {

--- a/app/src/main/java/it/niedermann/owncloud/notes/util/NotesClient.java
+++ b/app/src/main/java/it/niedermann/owncloud/notes/util/NotesClient.java
@@ -1,6 +1,7 @@
 package it.niedermann.owncloud.notes.util;
 
 import android.util.Base64;
+import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -87,11 +88,11 @@ public class NotesClient {
         return getNoteFromJSON(json);
     }
 
-    private OwnCloudNote putNote(OwnCloudNote note, String path)  throws JSONException, IOException {
+    private OwnCloudNote putNote(OwnCloudNote note, String path, String method)  throws JSONException, IOException {
         JSONObject paramObject = new JSONObject();
         paramObject.accumulate(key_content, note.getContent());
         paramObject.accumulate(key_modified, note.getModified().getTimeInMillis()/1000);
-        JSONObject json = new JSONObject(requestServer(path, METHOD_PUT, paramObject));
+        JSONObject json = new JSONObject(requestServer(path, method, paramObject));
         return getNoteFromJSON(json);
     }
 
@@ -104,11 +105,11 @@ public class NotesClient {
      * @throws IOException
      */
     public OwnCloudNote createNote(OwnCloudNote note) throws JSONException, IOException {
-        return putNote(note, "notes");
+        return putNote(note, "notes", METHOD_POST);
     }
 
     public OwnCloudNote editNote(OwnCloudNote note) throws JSONException, IOException {
-        return putNote(note, "notes/" + note.getRemoteId());
+        return putNote(note, "notes/" + note.getRemoteId(), METHOD_PUT);
     }
 
     public void deleteNote(long noteId) throws
@@ -139,7 +140,9 @@ public class NotesClient {
                         + new String(Base64.encode((username + ":"
                         + password).getBytes(), Base64.NO_WRAP)));
         con.setConnectTimeout(10 * 1000); // 10 seconds
+        Log.d(getClass().getSimpleName(), method + " " + targetURL);
         if (params != null) {
+            Log.d(getClass().getSimpleName(), "Params: "+params);
             con.setFixedLengthStreamingMode(params.toString().getBytes().length);
             con.setRequestProperty("Content-Type", application_json);
             con.setDoOutput(true);


### PR DESCRIPTION
After editing a note, the updated note is automatically put on the first position in the list of notes. This was suitable before #123. But now, a note should jump to the top only if the modified time increases.