### PR TITLE
Consolidate repeated and untranslatable names

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -59,13 +59,10 @@
     <string name="about_version_title">Verze</string>
     <string name="about_version">Právě používáte <strong>%1$s</strong></string>
     <string name="about_maintainer_title">Správce</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Vývojáři</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Překladatelé</string>
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testeři</string>
-    <string name="about_testers">Jan C. Borchardt</string>
     <string name="about_source_title">Source code</string>
     <string name="about_source">Projekt je hostovaný na GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Chyby</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,13 +62,10 @@
     <string name="about_version_title">Version</string>
     <string name="about_version">Sie benutzen aktuell <strong>%1$s</strong></string>
     <string name="about_maintainer_title">Maintainer</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Entwickler</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Übersetzer</string>
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Tester</string>
-    <string name="about_testers">Jan C. Borchardt</string>
     <string name="about_source_title">Quellcode</string>
     <string name="about_source">Dieses Projekt ist auf GitHub gehosted: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Tickets</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -59,13 +59,10 @@
     <string name="about_version_title">Version</string>
     <string name="about_version">Vous utilisez actuellement la <strong>%1$s</strong></string>
     <string name="about_maintainer_title">Responsable</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Developpeurs</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Traducteurs</string>
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testeurs</string>
-    <string name="about_testers">Jan C. Borchardt</string>
     <string name="about_source_title">Code source</string>
     <string name="about_source">Ce projet est hébergé sur GitHub : <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Bugs</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -61,13 +61,10 @@
     <string name="about_version_title">տարբերակ</string>
     <string name="about_version">դուք օգտագործում եք <strong>%1$s</strong></string>
     <string name="about_maintainer_title">ղեկավար</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">ծրագրավորող</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">թարգմանիչ</string>
     <string name="about_translators">Արթուր Դավթյան, ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">թեսթավորող</string>
-    <string name="about_testers">Jan C. Borchardt</string>
     <string name="about_source_title">ծրագրի կոդը</string>
     <string name="about_source">ծրագիրը տեղադրված է GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">հայց</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -59,13 +59,10 @@
     <string name="about_version_title">Versão</string>
     <string name="about_version">Está atualmente a usar a versão <strong>%1$s</strong></string>
     <string name="about_maintainer_title">Mantenedor</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Desenvolvedores</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Tradutores</string>
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian)</string>
     <string name="about_testers_title">Experimentadores</string>
-    <string name="about_testers">Jan C. Borchardt</string>
     <string name="about_source_title">Código fonte</string>
     <string name="about_source">Este projeto está alojado no GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Problemas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -58,11 +58,8 @@
 
     <!-- About -->
     <string name="about_version">Вы используете <strong>%1$s</strong></string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Разработчики</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators">pejakm (Сербский), ageru (Французский), proninyaroslav (Русский), mist (Чешский)</string>
-    <string name="about_testers">Jan C. Borchardt</string>
     <string name="about_source">Проект размещён на GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues">Вы можете сообщать об ошибках, предложениях об улучшении и пожеланиях в систему тикетов GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/issues">https://github.com/stefan-niedermann/OwnCloud-Notes/issues</a></string>
     <string name="about_app_license_title">Лицензия программы</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -62,13 +62,10 @@
     <string name="about_version_title">Издање</string>
     <string name="about_version">Текуће издање је <strong>%1$s</strong></string>
     <string name="about_maintainer_title">Главни програмер</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Програмери</string>
-    <string name="about_developers">Стефан Нидерман (Stefan Niedermann), HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Преводиоци</string>
     <string name="about_translators">Младен Пејаковић (српски), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Тестери</string>
-    <string name="about_testers">Јан Борхарт (Jan C. Borchardt)</string>
     <string name="about_source_title">Изворни кôд</string>
     <string name="about_source">Пројекат је хостован на Гитхабу: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Грешке</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,13 +65,13 @@
     <string name="about_version_title">Version</string>
     <string name="about_version">You are currently using <strong>%1$s</strong></string>
     <string name="about_maintainer_title">Maintainer</string>
-    <string name="about_maintainer"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
+    <string name="about_maintainer" translatable="false"><a href="http://www.niedermann.it/">Niedermann IT-Dienstleistungen</a></string>
     <string name="about_developers_title">Developers</string>
-    <string name="about_developers">Stefan Niedermann, HeaDBanGer84, Felix Edelmann</string>
+    <string name="about_developers" translatable="false">Stefan Niedermann, Kristof Hamann, HeaDBanGer84, Felix Edelmann</string>
     <string name="about_translators_title">Translators</string>
     <string name="about_translators">pejakm (Serbe), ageru (Français (France)), proninyaroslav (Russian), mist (Czech)</string>
     <string name="about_testers_title">Testers</string>
-    <string name="about_testers">Jan C. Borchardt</string>
+    <string name="about_testers" translatable="false">Jan C. Borchardt</string>
     <string name="about_source_title">Source code</string>
     <string name="about_source">This project is hosted on GitHub: <a href="https://github.com/stefan-niedermann/OwnCloud-Notes/">https://github.com/stefan-niedermann/OwnCloud-Notes/</a></string>
     <string name="about_issues_title">Issues</string>


### PR DESCRIPTION
I'm not sure if this is too cheeky, but after looking at the [contributors statistic](https://github.com/stefan-niedermann/OwnCloud-Notes/graphs/contributors), I've added myself to the developers. :sunglasses:

In order to be also productive, I've removed all (in my point of view) untranslatable (and hence identical for all languages) personal names from the translations and set `translatable="false"` for them. This should increase maintainability.